### PR TITLE
add support for some v8 flags including --harmony

### DIFF
--- a/bin/_matcha
+++ b/bin/_matcha
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// -*- mode: javascript -*-
+// vi: set ft=javascript :
+
+var electron = require('electron')
+  , matcha = require('..');
+
+var Interface = require('../lib/matcha/interface');
+
+var program = electron('matcha')
+  .name('Matcha')
+  .version(matcha.version)
+  .desc('https://github.com/logicalparadox/matcha')
+  .cwd(process.cwd())
+  .theme('simple', {
+      command: 'absent'
+    , usage: '<options> <files>'
+  });
+
+program
+  .command('absent')
+  .desc('Run a suite of benchmarks.')
+  .option('-h, --help', 'view matcha usage information')
+  .option('-v, --version', 'view matcha version')
+  .option('-R, --reporter [clean]', 'specify the reporter to use')
+  .option('-I, --interface [bdd]', 'specify the interface to expect')
+  .option('--interfaces', 'display available interfaces')
+  .option('--reporters', 'display available reporters  ')
+  .action(runSuite);
+
+program
+  .command('default')
+  .action(runSuite);
+
+program.parse();
+
+function runSuite (argv) {
+
+  var showInterfaces = argv.mode('interfaces');
+  if (showInterfaces) {
+    program.colorize();
+    console.log();
+    console.log('    bdd     - suite/bench style');
+    console.log('    exports - commonjs style interface');
+    process.exit();
+  }
+
+  var showReporters = argv.mode('reporters');
+  if (showReporters) {
+    program.colorize();
+    console.log();
+    console.log('    clean - clean list');
+    console.log('    plain - plain text list');
+    console.log('    csv   - comma seperated values');
+    process.exit();
+  }
+
+  var path = require('path')
+    , fs = require('fs')
+    , exists = fs.existsSync || path.existsSync
+    , cwd = argv.cwd
+    , files = argv.commands.slice(0)
+    , re = /\.js$/;
+
+  if (!files.length) {
+    if (!exists(path.join(cwd, 'benchmark'))) {
+      console.error('Matcha: cannot find default `benchmark` folder.');
+      process.exit(1);
+    }
+
+    files = fs.readdirSync(path.join(cwd, 'benchmark')).filter(function(path){
+      return path.match(re);
+    }).map(function(_p){
+      return path.join('benchmark', _p);
+    });
+  }
+
+  files = files.map(function(_p){
+    _p = require.resolve(path.join(cwd, _p));
+    return _p;
+  });
+
+  var style = argv.param('I', 'interface') || 'bdd'
+    , suite = new matcha.Suite()
+    , ui = new Interface(suite, { style: style });
+
+  // load reporter
+  try {
+    var rep = argv.param('R', 'reporter') || 'clean';
+    var Reporter = require('../lib/matcha/reporters/' + rep);
+  } catch (err) {
+    console.log(err)
+    console.log('reporter "' + rep + '" does not exist');
+    process.exit();
+  }
+
+  load(files, function () {
+    run(suite, process.exit);
+  });
+
+  function load (files, cb) {
+    var after = files.length
+    files.forEach(function (file) {
+      delete require.cache[file];
+      suite.emit('pre-require');
+      suite.emit('require', require(file));
+      --after || cb();
+    });
+  }
+
+  function run (suite, cb) {
+    var runner = new matcha.Runner(suite)
+      , reporter = new Reporter(runner);
+    runner.run(cb);
+  }
+
+};
+

--- a/bin/matcha
+++ b/bin/matcha
@@ -1,118 +1,46 @@
 #!/usr/bin/env node
-// -*- mode: javascript -*-
-// vi: set ft=javascript :
 
-var electron = require('electron')
-  , matcha = require('..');
+var spawn = require('child_process').spawn;
+var args = [__dirname + '/_matcha'];
 
-var Interface = require('../lib/matcha/interface');
+process.argv.slice(2).forEach(function(arg){
+  var flag = arg.split('=')[0];
 
-var program = electron('matcha')
-  .name('Matcha')
-  .version(matcha.version)
-  .desc('https://github.com/logicalparadox/matcha')
-  .cwd(process.cwd())
-  .theme('simple', {
-      command: 'absent'
-    , usage: '<options> <files>'
-  });
-
-program
-  .command('absent')
-  .desc('Run a suite of benchmarks.')
-  .option('-h, --help', 'view matcha usage information')
-  .option('-v, --version', 'view matcha version')
-  .option('-R, --reporter [clean]', 'specify the reporter to use')
-  .option('-I, --interface [bdd]', 'specify the interface to expect')
-  .option('--interfaces', 'display available interfaces')
-  .option('--reporters', 'display available reporters  ')
-  .action(runSuite);
-
-program
-  .command('default')
-  .action(runSuite);
-
-program.parse();
-
-function runSuite (argv) {
-
-  var showInterfaces = argv.mode('interfaces');
-  if (showInterfaces) {
-    program.colorize();
-    console.log();
-    console.log('    bdd     - suite/bench style');
-    console.log('    exports - commonjs style interface');
-    process.exit();
+  switch (flag) {
+    case '-d':
+      args.unshift('--debug');
+      break;
+    case 'debug':
+    case '--debug':
+    case '--debug-brk':
+      args.unshift(arg);
+      break;
+    case '-gc':
+    case '--expose-gc':
+      args.unshift('--expose-gc');
+      break;
+    case '--gc-global':
+    case '--harmony':
+    case '--harmony-proxies':
+    case '--harmony-collections':
+    case '--harmony-generators':
+    case '--prof':
+      args.unshift(arg);
+      break;
+    default:
+      if (0 == arg.indexOf('--trace')) args.unshift(arg);
+      else args.push(arg);
+      break;
   }
+});
 
-  var showReporters = argv.mode('reporters');
-  if (showReporters) {
-    program.colorize();
-    console.log();
-    console.log('    clean - clean list');
-    console.log('    plain - plain text list');
-    console.log('    csv   - comma seperated values');
-    process.exit();
-  }
-
-  var path = require('path')
-    , fs = require('fs')
-    , exists = fs.existsSync || path.existsSync
-    , cwd = argv.cwd
-    , files = argv.commands.slice(0)
-    , re = /\.js$/;
-
-  if (!files.length) {
-    if (!exists(path.join(cwd, 'benchmark'))) {
-      console.error('Matcha: cannot find default `benchmark` folder.');
-      process.exit(1);
+var proc = spawn(process.argv[0], args, { customFds: [0,1,2] });
+proc.on('exit', function (code, signal) {
+  process.on('exit', function(){
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code);
     }
-
-    files = fs.readdirSync(path.join(cwd, 'benchmark')).filter(function(path){
-      return path.match(re);
-    }).map(function(_p){
-      return path.join('benchmark', _p);
-    });
-  }
-
-  files = files.map(function(_p){
-    _p = require.resolve(path.join(cwd, _p));
-    return _p;
   });
-
-  var style = argv.param('I', 'interface') || 'bdd'
-    , suite = new matcha.Suite()
-    , ui = new Interface(suite, { style: style });
-
-  // load reporter
-  try {
-    var rep = argv.param('R', 'reporter') || 'clean';
-    var Reporter = require('../lib/matcha/reporters/' + rep);
-  } catch (err) {
-    console.log(err)
-    console.log('reporter "' + rep + '" does not exist');
-    process.exit();
-  }
-
-  load(files, function () {
-    run(suite, process.exit);
-  });
-
-  function load (files, cb) {
-    var after = files.length
-    files.forEach(function (file) {
-      delete require.cache[file];
-      suite.emit('pre-require');
-      suite.emit('require', require(file));
-      --after || cb();
-    });
-  }
-
-  function run (suite, cb) {
-    var runner = new matcha.Runner(suite)
-      , reporter = new Reporter(runner);
-    runner.run(cb);
-  }
-
-};
-
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "main": "index",
   "bin": {
-    "matcha": "./bin/matcha"
+    "matcha": "./bin/matcha",
+    "_matcha": "./bin/_matcha"
   },
   "scripts": {},
   "engines": {


### PR DESCRIPTION
totally up to you I'm alright with using the fork, the "proxy" executable could be a shell script too. This might become common enough between executables that we may want to consider making it a real module that mocha/matcha/whatever can share
