### PR TITLE
Shim process.stdout.write for browserify compatibility

### DIFF
--- a/lib/matcha/reporters/plain.js
+++ b/lib/matcha/reporters/plain.js
@@ -14,7 +14,12 @@ function pad(str, width) {
   return str + ' ' + Array(width - str.length-2).join('.') + ' ';
 };
 
-
+// process.stdout.write shim for browserify
+if (typeof process.stdout === 'undefined') {
+  process.stdout = {
+    write: console.log.bind(console)
+  }
+}
 
 /**
  * Plain


### PR DESCRIPTION
It's possible to use matcha in the browser using browserify and testling.  However, using the plain reporter is not possible because `process.stdout.write` is not supported.  This change adds a fallback to the plain reporter.
