### PR TITLE
Use version from package.json

### DIFF
--- a/lib/matcha.js
+++ b/lib/matcha.js
@@ -4,9 +4,8 @@
  * MIT Licensed
  */
 
-exports.version = '0.6.0';
+exports.version = require('../package.json').version;
 exports.Bench = require('./matcha/bench');
 exports.Suite = require('./matcha/suite');
 exports.Runner = require('./matcha/runner');
 exports.utils = require('./matcha/utils');
-


### PR DESCRIPTION
The version in `lib/matcha.js` isn't up to date. Use the version from `package.json` - only one place for maintaining. 😉 
