### PR TITLE
 Use `process.cpuUsage()` instead of `process.hrtime()`

### DIFF
--- a/lib/matcha/timer/cpuUsage.js
+++ b/lib/matcha/timer/cpuUsage.js
@@ -1,0 +1,69 @@
+/*!
+ * Matcha - High-res timer for Node.js
+ * Copyright(c) 2012 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/*!
+ * Primary Export
+ */
+
+module.exports = Timer;
+
+/**
+ * Timer (constructor)
+ *
+ * Constructs a timer that will return a high accuracy
+ * elapsed calculation.
+ *
+ * @api public
+ */
+
+function Timer () {
+  this._start = null;
+  this._elapsed = null;
+}
+
+/**
+ * .elapsed
+ *
+ * Calculate the milliseconds elapsed time
+ * for the given elapsed hrdiff.
+ *
+ * @returns Number ms elapsed since start
+ */
+
+Object.defineProperty(Timer.prototype, 'elapsed',
+  { get: function () {
+      if (!this._elapsed) return null;
+      var {user, system} = this._elapsed;
+      return (user+system)
+    }
+});
+
+/**
+ * .start ()
+ *
+ * Mark the starting point for this timer.
+ *
+ * @api public
+ */
+
+Timer.prototype.start = function () {
+  this._start = process.cpuUsage();
+  return this;
+};
+
+/**
+ * .stop ()
+ *
+ * Mark the stopping point for this timer.
+ * using hrtimes built in differ capability.
+ *
+ * @api public
+ */
+
+Timer.prototype.stop = function () {
+  this._elapsed = process.cpuUsage(this._start);
+  return this;
+};

--- a/lib/matcha/timer/cpuUsage.js
+++ b/lib/matcha/timer/cpuUsage.js
@@ -37,7 +37,7 @@ Object.defineProperty(Timer.prototype, 'elapsed',
   { get: function () {
       if (!this._elapsed) return null;
       var {user, system} = this._elapsed;
-      return (user+system)
+      return (user+system)/1000
     }
 });
 

--- a/lib/matcha/timer/index.js
+++ b/lib/matcha/timer/index.js
@@ -1,3 +1,9 @@
-module.exports = process && 'function' === typeof process.hrtime
-  ? require('./hrtimer')
-  : require('./date');
+if (process) {
+  if (typeof process.cpuUsage === 'function') {
+    module.exports = require('./cpuUsage')
+  } else if (typeof process.hrtime === 'function') {
+    module.exports = require('./hrtimer')
+  }
+} else {
+ module.exports =  require('./date')
+}


### PR DESCRIPTION
In benchmarking, the real world time is not suggested because the real world running time of a function is influenced by other running programs (like browsers, slates, Mail...).  This PR use `process.cpuUsage`, counting only the cpu usage time and excluding the idling time.