### PR TITLE
docs: Fix simple typo, asyncronous -> asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Matcha is available on npm.
 
 ## Writing Async Benchmarks
 
-Though suites/benches are executed serially, the benches themselves can be asyncronous. Furthermore, suites ran with
+Though suites/benches are executed serially, the benches themselves can be asynchronous. Furthermore, suites ran with
 the matcha command line runner have a number of globals to simplify bench definitions. Take the following code, for example:
 
 ```js

--- a/lib/matcha/bench.js
+++ b/lib/matcha/bench.js
@@ -159,7 +159,7 @@ function doSync (fn, iterations, concurrency, next) {
 /*!
  * doAsync (fn, iterations, next)
  *
- * Run an asyncronous bench function
+ * Run an asynchronous bench function
  * a set number of iterations.
  *
  * @param {Function} bench function


### PR DESCRIPTION
There is a small typo in README.md, lib/matcha/bench.js.

Should read `asynchronous` rather than `asyncronous`.

